### PR TITLE
Build and test Windows builds on github actions.

### DIFF
--- a/.github/workflows/scoreboard-coverage.yml
+++ b/.github/workflows/scoreboard-coverage.yml
@@ -5,7 +5,7 @@ on:
     - cron: "0 2 * * *" # 2 am every morning
 
 jobs:
-  test:
+  coverage:
     runs-on: ${{ matrix.os }}
     container:
       # Always use the main branch for coverage
@@ -25,43 +25,51 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Configure Cmake
-      run: >
-        cmake -B out/${{ matrix.build_type }}
-        -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
-        -DSKIP_LINT=false
-        -DINTEGRATION_TEST=true
-        -DENABLE_CODE_COVERAGE=true
-        -DCMAKE_CXX_FLAGS=-DSCOREBOARD_ENABLE_LOGGING
-  
-    - name: Build
-      run: >
-        cmake --build out/${{ matrix.build_type }} --parallel 4 --config ${{ matrix.build_type }}
+    - name: Build Scoreboard
+      uses: threeal/cmake-action@main
+      env:
+        VCPKG_ROOT: ${{ github.workspace }}/vcpkg # Only used in win-64, ignored in other platforms.
+        WXWIDGETS_ROOT: ${{ github.workspace }}/wx # Only used in win-64, ignored in other platforms.
+      with:
+        source-dir: ${{ github.workspace }}
+        build-dir: ${{ github.workspace }}/out/${{ matrix.target_os }}/${{ matrix.build_type }}
+        options: 
+          CMAKE_BUILD_TYPE=${{ matrix.build_type }}
+          SKIP_LINT=false
+          INTEGRATION_TEST=true
+          ENABLE_CODE_COVERAGE=true
+          CMAKE_CXX_FLAGS=-DSCOREBOARD_ENABLE_LOGGING
+
+    - name: Pre-Test Setup
+      run: sudo supervisord -c /supervisord.conf
 
     - name: Test
-      run: >
-        etc/github_actions/run_automated_tests.sh ${{ matrix.build_type }}
+      uses: threeal/ctest-action@v1.0.0
+      with:
+        test-dir: out/${{ matrix.target_os }}/${{ matrix.build_type }}
+        build-config: ${{ matrix.build_type }}
+        args: --no-compress-output
 
     - name: Coverage
-      run: >
-        etc/github_actions/run_coverage_tests.sh ${{ matrix.build_type }}
+      working-directory: out/${{matrix.target_os}}/${{ matrix.build_type }}
+      run: make -j6 all cszb-scoreboard-xml-coverage
 
     - name: Archive test results
       uses: actions/upload-artifact@v4
       with:
         name: test-results-${{ matrix.build_type }}
         path: |
-            out/${{ matrix.build_type }}/gtest/**/*.xml
-            out/${{ matrix.build_type }}/Testing/**/*.xml
+            out/${{ matrix.target_os }}/${{ matrix.build_type }}/gtest/**/*.xml
+            out/${{ matrix.target_os }}/${{ matrix.build_type }}/Testing/**/*.xml
 
     - name: Test Report
       uses: EnricoMi/publish-unit-test-result-action@v2
       if: always()
       with:
-        files: out/${{ matrix.build_type }}/gtest/**/*.xml
+        files: out/${{ matrix.target_os }}/${{ matrix.build_type }}/gtest/**/*.xml
 
     - name: Coverage Report
       uses: 5monkeys/cobertura-action@master
       with:
-        path: out/${{ matrix.build_type }}/cszb-scoreboard-xml-coverage.xml
+        path: out/${{ matrix.target_os }}/${{ matrix.build_type }}/cszb-scoreboard-xml-coverage.xml
         minimum_coverage: 25

--- a/.github/workflows/scoreboard.yml
+++ b/.github/workflows/scoreboard.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ "master" ]
 
+env:
+  vcpkg_commit: 4044645043df0cb62e35ac91042221731153e1bb
+  wxwidget_commit: 44b99195bc4395944bab8071c6d7adcbdcdf8773
+
 jobs:
   docker_build:
     runs-on: ${{ matrix.os }}
@@ -60,98 +64,233 @@ jobs:
         cache-from: type=registry,ref=${{ steps.strings.outputs.cache-branch }}
         cache-to: type=registry,ref=${{ steps.strings.outputs.cache-branch }}
 
-  build:
+  wxwidgets_build:
     runs-on: ${{ matrix.os }}
-    needs: [docker_build]
-    container:
-      image: ghcr.io/akbarthegreat/cszb_scoreboard_${{ matrix.docker_target }}_${{ github.head_ref || github.ref_name }}:latest
 
     strategy:
       fail-fast: true
 
       matrix:
-        target_os: [linux, macos]
+        target_os: [win64]
+        build_type: [Release, Debug]
+        include:
+          - target_os: win64
+            os: windows-latest
+
+    steps:
+    - name: Cache wxWidgets install
+      id: cache-wx-install
+      uses: actions/cache@v4
+      env:
+        cache-name: cache-wx-install
+      with:
+        path: ./wx/x64-${{ matrix.build_type }}
+        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ matrix.build_type }}-${{ env.wxwidget_commit }}
+        restore-keys: |
+          ${{ runner.os }}-build-${{ env.cache-name }}-${{ matrix.build_type }}-
+          ${{ runner.os }}-build-${{ env.cache-name }}-
+          ${{ runner.os }}-build-
+          ${{ runner.os }}-
+
+    - name: Checkout wxWidgets
+      if: ${{ steps.cache-wx-install.outputs.cache-hit != 'true' }}
+      run: |
+        git clone https://github.com/wxWidgets/wxWidgets.git  wxwidgets
+        cd wxwidgets
+        git fetch --all --tags
+        git checkout ${{ env.wxwidget_commit }}
+        git submodule update --init --recursive
+
+    - name: Build wxWidgets
+      if: ${{ steps.cache-wx-install.outputs.cache-hit != 'true' }}
+      uses: threeal/cmake-action@main
+      with:
+        source-dir: ${{ github.workspace }}/wxwidgets
+        build-dir: ${{ github.workspace }}/wxwidgets/out/${{ matrix.target_os }}/${{ matrix.build_type }}
+        build-args: --config ${{ matrix.build_type }}
+        options: 
+                 wxBUILD_SHARED=OFF
+                 wxBUILD_SAMPLES=OFF
+                 wxBUILD_MONOLITHIC=OFF
+                 wxBUILD_USE_STATIC_RUNTIME=ON
+                 wxUSE_XLOCALE=OFF
+                 wxUSE_WEBVIEW_WEBKIT=ON
+                 wxUSE_WEBVIEW_EDGE=ON
+                 wxUSE_WEBVIEW_EDGE_STATIC=ON
+                 CMAKE_BUILD_TYPE=${{ matrix.build_type }}
+
+    - name: Install wxWidgets
+      if: ${{ steps.cache-wx-install.outputs.cache-hit != 'true' }}
+      working-directory: ./wxwidgets
+      run: >
+        cmake
+        --install out/${{ matrix.target_os }}/${{ matrix.build_type }}
+        --config ${{ matrix.build_type }}
+        --prefix ${{ github.workspace }}/wx/x64-${{ matrix.build_type }}
+
+  build:
+    runs-on: ${{ matrix.os }}
+    needs: [docker_build, wxwidgets_build]
+    container:
+      image: ${{ matrix.image }}
+
+    strategy:
+      fail-fast: true
+
+      matrix:
+        target_os: [linux, macos, win64]
         build_type: [Release, Debug]
         include:
           - target_os: linux
-            docker_target: standard_build
             os: ubuntu-latest
             test: true
-            build_target: all
+            image: ghcr.io/akbarthegreat/cszb_scoreboard_standard_build_${{ github.head_ref || github.ref_name }}:latest
           - target_os: macos
-            docker_target: macos_build
             os: ubuntu-latest
             test: false
-            cmake_args:  >
-                -DCMAKE_OSX_DEPLOYMENT_TARGET=10.12
-                -DCMAKE_TOOLCHAIN_FILE=/opt/osxcross/toolchain.cmake
-                -DOPENSSL_ROOT_DIR=/opt/osxcross/macports/pkgs/opt/local/libexec/openssl3
             env:
               - LD_LIBRARY_PATH='/opt/osxcross/lib'
-            build_target: cszb-scoreboard
+            build_args: --target cszb-scoreboard
+            image: ghcr.io/akbarthegreat/cszb_scoreboard_macos_build_${{ github.head_ref || github.ref_name }}:latest
+          - target_os: macos
+            build_type: Debug
+            cmake_args:  --preset=Mac-Debug
+          - target_os: macos
+            build_type: Release
+            cmake_args:  --preset=Mac-Release
+          - target_os: win64
+            os: windows-latest
+            test: true
+          - target_os: win64
+            build_type: Debug
+            cmake_args: --preset=Debug
+          - target_os: win64
+            build_type: Release
+            cmake_args: --preset=Release
     steps:
     - uses: actions/checkout@v4
 
-    - name: Configure Cmake
-      run: >
-        cmake -B out/${{ matrix.build_type }}
-        -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
-        -DSKIP_LINT=true
-        -DINTEGRATION_TEST=false
-        ${{ matrix.cmake_args }}
+    - name: Setup vckpkg
+      if: ${{ matrix.target_os == 'win64' }}
+      uses: lukka/run-vcpkg@v11
+      with:
+        vcpkgGitCommitId: '${{ env.vcpkg_commit }}'
 
-    - name: Build
-      run: >
-        cmake --build out/${{ matrix.build_type }} --parallel 4 --config ${{ matrix.build_type }} --target ${{ matrix.build_target }}
+    - name: Cache wxWidgets install
+      if: ${{ matrix.target_os == 'win64' }}
+      id: cache-wx-install
+      uses: actions/cache@v4
+      env:
+        cache-name: cache-wx-install
+      with:
+        path: ./wx/x64-${{ matrix.build_type }}
+        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ matrix.build_type }}-${{ env.wxwidget_commit }}
+        restore-keys: |
+          ${{ runner.os }}-build-${{ env.cache-name }}-${{ matrix.build_type }}-
+          ${{ runner.os }}-build-${{ env.cache-name }}-
+          ${{ runner.os }}-build-
+          ${{ runner.os }}-
+
+    - name: Build Scoreboard
+      uses: threeal/cmake-action@main
+      env:
+        VCPKG_ROOT: ${{ github.workspace }}/vcpkg # Only used in win-64, ignored in other platforms.
+        WXWIDGETS_ROOT: ${{ github.workspace }}/wx # Only used in win-64, ignored in other platforms.
+      with:
+        source-dir: ${{ github.workspace }}
+        build-dir: ${{ github.workspace }}/out/${{ matrix.target_os }}/${{ matrix.build_type }}
+        args: ${{ matrix.cmake_args }}
+        build-args: ${{ matrix.cmake_args }} ${{ matrix.build_args }}
+        options: 
+          CMAKE_BUILD_TYPE=${{ matrix.build_type }}
+          SKIP_LINT=true
+          INTEGRATION_TEST=false
 
   test:
     runs-on: ${{ matrix.os }}
     needs: [docker_build]
     container:
-      image: ghcr.io/akbarthegreat/cszb_scoreboard_${{ matrix.docker_target }}_${{ github.head_ref || github.ref_name }}:latest
+      image: ${{ matrix.image }}
 
     strategy:
       fail-fast: true
 
       matrix:
-        target_os: [linux]
+        target_os: [linux, win64]
         build_type: [Release, Debug]
         include:
           - target_os: linux
-            docker_target: standard_build
             os: ubuntu-latest
             test: true
+            image: ghcr.io/akbarthegreat/cszb_scoreboard_standard_build_${{ github.head_ref || github.ref_name }}:latest
+          - target_os: win64
+            os: windows-latest
+            test: true
+          - target_os: win64
+            build_type: Debug
+            cmake_args: --preset=Debug
+          - target_os: win64
+            build_type: Release
+            cmake_args: --preset=Release
 
     steps:
     - uses: actions/checkout@v4
 
-    - name: Configure Cmake
-      run: >
-        cmake -B out/${{ matrix.build_type }}
-        -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
-        -DSKIP_LINT=true
-        -DINTEGRATION_TEST=false
+    - name: Setup vckpkg
+      if: ${{ matrix.target_os == 'win64' }}
+      uses: lukka/run-vcpkg@v11
+      with:
+        vcpkgGitCommitId: '${{ env.vcpkg_commit }}'
 
-    - name: Build
-      run: >
-        cmake --build out/${{ matrix.build_type }} --parallel 4 --config ${{ matrix.build_type }}
+    - name: Cache wxWidgets install
+      if: ${{ matrix.target_os == 'win64' }}
+      id: cache-wx-install
+      uses: actions/cache@v4
+      env:
+        cache-name: cache-wx-install
+      with:
+        path: ./wx/x64-${{ matrix.build_type }}
+        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ matrix.build_type }}-${{ env.wxwidget_commit }}
+        restore-keys: |
+          ${{ runner.os }}-build-${{ env.cache-name }}-${{ matrix.build_type }}-
+          ${{ runner.os }}-build-${{ env.cache-name }}-
+          ${{ runner.os }}-build-
+          ${{ runner.os }}-
+
+    - name: Build Scoreboard
+      uses: threeal/cmake-action@main
+      env:
+        VCPKG_ROOT: ${{ github.workspace }}/vcpkg # Only used in win-64, ignored in other platforms.
+        WXWIDGETS_ROOT: ${{ github.workspace }}/wx # Only used in win-64, ignored in other platforms.
+      with:
+        source-dir: ${{ github.workspace }}
+        build-dir: ${{ github.workspace }}/out/${{ matrix.target_os }}/${{ matrix.build_type }}
+        args: ${{ matrix.cmake_args }}
+        build-args: ${{ matrix.cmake_args }}
+        options: 
+          CMAKE_BUILD_TYPE=${{ matrix.build_type }}
+          SKIP_LINT=true
+          INTEGRATION_TEST=false
 
     - name: Test
       if: ${{ matrix.test }}
-      run: >
-        etc/github_actions/run_automated_tests.sh ${{ matrix.build_type }}
+      uses: threeal/ctest-action@v1.0.0
+      with:
+        test-dir: out/${{ matrix.target_os }}/${{ matrix.build_type }}
+        build-config: ${{ matrix.build_type }}
+        args: --no-compress-output
 
     - name: Archive test results
       uses: actions/upload-artifact@v4
       if: ${{ matrix.test }}
       with:
-        name: test-results-${{ matrix.build_type }}
+        name: test-results-${{ matrix.target_os }}-${{ matrix.build_type }}
         path: |
-            out/${{ matrix.build_type }}/gtest/**/*.xml
-            out/${{ matrix.build_type }}/Testing/**/*.xml
+            out/${{ matrix.target_os }}/${{ matrix.build_type }}/gtest/**/*.xml
+            out/${{ matrix.target_os }}/${{ matrix.build_type }}/Testing/**/*.xml
 
     - name: Test Report
       uses: EnricoMi/publish-unit-test-result-action@v2
-      if: ${{ matrix.test }}
+      if: ${{ matrix.test && matrix.target_os != 'win64' }}
       with:
-        files: out/${{ matrix.build_type }}/gtest/**/*.xml
+        files: out/${{ matrix.target_os }}/${{ matrix.build_type }}/gtest/**/*.xml

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -3,45 +3,122 @@
    "configurePresets": [
       {
          "name": "Debug",
+         "displayName": "Debug",
          "generator": "Visual Studio 17 2022",
-         "binaryDir": "${sourceDir}/out/build/Debug",
+         "binaryDir": "${sourceDir}/out/win64/Debug",
          "cacheVariables": {
             "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
             "VCPKG_TARGET_TRIPLET": "x64-windows-static",
             "CMAKE_BUILD_TYPE": "Debug",
             "INTEGRATION_TEST": "False",
             "WXWIDGETS_INSTALL_DIR": "$env{WXWIDGETS_ROOT}/x64-Debug",
-            "WXWIDGETS_VERSION": "33",
-            "IMAGE_SEARCH": "True"
+            "WXWIDGETS_VERSION": "33"
          }
       },
       {
-         "name": "Debug Integration",
-         "generator": "Visual Studio 17 2022",
-         "binaryDir": "${sourceDir}/out/build/DebugIntegration",
+         "name": "Integration",
+         "displayName": "Debug Integration",
+         "inherits": "Debug",
+         "binaryDir": "${sourceDir}/out/win64/DebugIntegration",
          "cacheVariables": {
-            "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
-            "VCPKG_TARGET_TRIPLET": "x64-windows-static",
-            "CMAKE_BUILD_TYPE": "Debug",
-            "INTEGRATION_TEST": "True",
-            "WXWIDGETS_INSTALL_DIR": "$env{WXWIDGETS_ROOT}/x64-Debug",
-            "WXWIDGETS_VERSION": "33",
-            "IMAGE_SEARCH": "True"
+            "INTEGRATION_TEST": "True"
          }
       },
       {
          "name": "Release",
-         "generator": "Visual Studio 17 2022",
-         "binaryDir": "${sourceDir}/out/build/Release",
+         "displayName": "Release",
+         "inherits": "Debug",
+         "binaryDir": "${sourceDir}/out/win64/Release",
          "cacheVariables": {
-            "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
-            "VCPKG_TARGET_TRIPLET": "x64-windows-static",
             "CMAKE_BUILD_TYPE": "Release",
-            "INTEGRATION_TEST": "False",
-            "WXWIDGETS_INSTALL_DIR": "$env{WXWIDGETS_ROOT}/x64-Debug",
-            "WXWIDGETS_VERSION": "33",
-            "IMAGE_SEARCH": "True"
+            "WXWIDGETS_INSTALL_DIR": "$env{WXWIDGETS_ROOT}/x64-Release"
          }
+      },
+      {
+         "name": "Linux-Debug",
+         "displayName": "Linux Debug",
+         "generator": "Unix Makefiles",
+         "binaryDir": "${sourceDir}/out/linux/Debug",
+         "cacheVariables": {
+            "CMAKE_BUILD_TYPE": "Debug",
+            "SKIP_LINT": "true",
+            "INTEGRATION_TEST": "false"
+         }
+      },
+      {
+         "name": "Linux-Release",
+         "displayName": "Linux Release",
+         "inherits": "Linux-Debug",
+         "binaryDir": "${sourceDir}/out/linux/Release",
+         "cacheVariables": {
+            "CMAKE_BUILD_TYPE": "Release"
+         }
+      },
+      {
+         "name": "Mac-Debug",
+         "displayName": "MacOS Debug",
+         "inherits": "Linux-Debug",
+         "binaryDir": "${sourceDir}/out/macos/Debug",
+         "cacheVariables": {
+            "CMAKE_OSX_DEPLOYMENT_TARGET": "10.12",
+            "CMAKE_TOOLCHAIN_FILE": "/opt/osxcross/toolchain.cmake",
+            "OPENSSL_ROOT_DIR": "/opt/osxcross/macports/pkgs/opt/local/libexec/openssl3"
+         }
+      },
+      {
+         "name": "Mac-Release",
+         "displayName": "MacOS Release",
+         "inherits": "Linux-Release",
+         "binaryDir": "${sourceDir}/out/macos/Release",
+         "cacheVariables": {
+            "CMAKE_OSX_DEPLOYMENT_TARGET": "10.12",
+            "CMAKE_TOOLCHAIN_FILE": "/opt/osxcross/toolchain.cmake",
+            "OPENSSL_ROOT_DIR": "/opt/osxcross/macports/pkgs/opt/local/libexec/openssl3"
+         }
+      }
+   ],
+   "buildPresets": [
+      {
+         "name": "Debug",
+         "displayName": "Debug",
+         "configurePreset": "Debug",
+         "configuration": "Debug"
+      },
+      {
+         "name": "Integration",
+         "displayName": "Debug Integration",
+         "inherits": "Debug",
+         "configurePreset": "Integration"
+      },
+      {
+         "name": "Release",
+         "displayName": "Release",
+         "configurePreset": "Release",
+         "configuration": "Release"
+      },
+      {
+         "name": "Linux-Debug",
+         "displayName": "Linux Debug",
+         "configurePreset": "Linux-Debug",
+         "configuration": "Debug"
+      },
+      {
+         "name": "Linux-Release",
+         "displayName": "Linux Release",
+         "configurePreset": "Linux-Release",
+         "configuration": "Release"
+      },
+      {
+         "name": "Mac-Debug",
+         "displayName": "Mac Debug",
+         "configurePreset": "Mac-Debug",
+         "configuration": "Debug"
+      },
+      {
+         "name": "Mac-Release",
+         "displayName": "Mac Release",
+         "configurePreset": "Mac-Release",
+         "configuration": "Release"
       }
    ]
 }

--- a/cmake/winmsvc.cmake
+++ b/cmake/winmsvc.cmake
@@ -72,7 +72,6 @@ if("${CMAKE_BUILD_TYPE}" MATCHES "Debug")
 			${wxWidgets_LIB_DIR}/wxpngd.lib
 			${wxWidgets_LIB_DIR}/wxtiffd.lib
 			${wxWidgets_LIB_DIR}/wxzlibd.lib
-			${wxWidgets_LIB_DIR}/WebView2LoaderStatic.lib
 		)
 	else() # Using VCPKG
 		set(wxWidgets_LIB_DIR ${VCPKG_BASE}/debug/lib)
@@ -108,7 +107,6 @@ elseif("${CMAKE_BUILD_TYPE}" MATCHES "Release") # Not Debug, check Release
 			${wxWidgets_LIB_DIR}/wxpng.lib
 			${wxWidgets_LIB_DIR}/wxtiff.lib
 			${wxWidgets_LIB_DIR}/wxzlib.lib
-			${wxWidgets_LIB_DIR}/WebView2LoaderStatic.lib
 		)
 	else() # Using VCPKG
 		set(wxWidgets_LIB_DIR ${VCPKG_BASE}/lib)
@@ -136,9 +134,12 @@ elseif("${CMAKE_BUILD_TYPE}" MATCHES "Release") # Not Debug, check Release
 	endif() # if LINKING_TYPE == "static"
 endif() # if CMAKE_BUILD_TYPE == "Debug"
 
+find_package(unofficial-webview2 CONFIG REQUIRED)
+
 set(wxWidgets_LIBRARIES
 	${wxWidgets_LIBRARIES}
 	comctl32 Rpcrt4
+	unofficial::webview2::webview2
 )
 
 # I hate doing this, but wxWidgets produces way too many warnings in this category and obscures problems in my code.

--- a/etc/github_actions/run_automated_tests.sh
+++ b/etc/github_actions/run_automated_tests.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-# Run during the GitHub action for CI -- should be run in a Docker container.
-
-sudo supervisord -c /supervisord.conf
-cd out/$1
-ctest -T Test --output-on-failure --no-compress-output --build-config $1
-

--- a/etc/github_actions/run_coverage_tests.sh
+++ b/etc/github_actions/run_coverage_tests.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-# Run during the GitHub action for CI -- should be run in a Docker container.
-
-sudo supervisord -c /supervisord.conf
-cd out/$1
-make -j6 all cszb-scoreboard-xml-coverage
-

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -4,6 +4,6 @@
     "gtest",
     "jsoncpp",
     "protobuf",
-    "wxwidgets"
+    "webview2"
   ]
 }


### PR DESCRIPTION
- Use defined actions for all of our cmake work.
- Add a job to prep a cached built of wxWidgets for Windows.
- Switch over to Github actions for cmake & ctest (only cmake install is missing)