### PR TITLE
Refocus the main window after dragging from the embedded browser.

### DIFF
--- a/src/ui/component/control/ImageSearch.cpp
+++ b/src/ui/component/control/ImageSearch.cpp
@@ -127,6 +127,8 @@ void ImageSearch::onURLDrop(const std::string &url) {
     home_screen_image = urlImage;
   }
 
+  drop_target->focus();
+
   control_panel->update();
   updatePreview();
 }


### PR DESCRIPTION
This is a workaround for issue #41, and should resolve most users' pain points with this misbehavior.